### PR TITLE
Feat get drink images & Refactor isLiked

### DIFF
--- a/src/main/java/kuit/project/beering/controller/DrinkController.java
+++ b/src/main/java/kuit/project/beering/controller/DrinkController.java
@@ -31,7 +31,7 @@ public class DrinkController {
             @RequestParam(defaultValue = "2147483647", required = false) Integer maxPrice,
             @AuthenticationPrincipal AuthMember member
     ) {
-        Page<DrinkSearchResponse> result = drinkService.searchDrinksByName(member.getId(), page, orderBy, new DrinkSearchCondition(name, name, category, minPrice, maxPrice));
+        Page<DrinkSearchResponse> result = drinkService.searchDrinksByName(page, orderBy, new DrinkSearchCondition(name, name, category, minPrice, maxPrice, member.getId()));
         return new BaseResponse<>(result);
     }
 

--- a/src/main/java/kuit/project/beering/dto/request/drink/DrinkSearchCondition.java
+++ b/src/main/java/kuit/project/beering/dto/request/drink/DrinkSearchCondition.java
@@ -11,4 +11,5 @@ public class DrinkSearchCondition {
     String categoryName;
     Integer minPrice;
     Integer maxPrice;
+    Long memberId;
 }

--- a/src/main/java/kuit/project/beering/dto/response/drink/DrinkSearchResponse.java
+++ b/src/main/java/kuit/project/beering/dto/response/drink/DrinkSearchResponse.java
@@ -5,15 +5,17 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.List;
+
 @Getter
 @Setter
 @AllArgsConstructor
 @Builder
 public class DrinkSearchResponse {
-    Long beerId;
-    String imgUrl;
+    Long drinkId;
     String nameKr;
     String nameEn;
     String manufacturer;
+    List<String> imageUrlList;
     Boolean isLiked;
 }

--- a/src/main/java/kuit/project/beering/repository/CustomDrinkRepository.java
+++ b/src/main/java/kuit/project/beering/repository/CustomDrinkRepository.java
@@ -2,12 +2,13 @@ package kuit.project.beering.repository;
 
 import kuit.project.beering.domain.Drink;
 import kuit.project.beering.dto.request.drink.DrinkSearchCondition;
+import kuit.project.beering.dto.response.drink.DrinkSearchResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CustomDrinkRepository {
-    Page<Drink> search(DrinkSearchCondition drinkSearchCondition, Pageable pageable);
+    Page<DrinkSearchResponse> search(DrinkSearchCondition drinkSearchCondition, Pageable pageable);
 
 }

--- a/src/main/java/kuit/project/beering/repository/CustomDrinkRepositoryImpl.java
+++ b/src/main/java/kuit/project/beering/repository/CustomDrinkRepositoryImpl.java
@@ -2,12 +2,14 @@ package kuit.project.beering.repository;
 
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
-import kuit.project.beering.domain.Drink;
 import kuit.project.beering.dto.request.drink.DrinkSearchCondition;
+import kuit.project.beering.dto.response.drink.DrinkSearchResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,9 +17,11 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.util.StringUtils;
 
+import java.util.Collections;
 import java.util.List;
 
 import static kuit.project.beering.domain.QDrink.*;
+import static kuit.project.beering.domain.QFavorite.favorite;
 
 @Slf4j
 public class CustomDrinkRepositoryImpl implements CustomDrinkRepository {
@@ -27,15 +31,28 @@ public class CustomDrinkRepositoryImpl implements CustomDrinkRepository {
         this.jpaQueryFactory = new JPAQueryFactory(em);
     }
 
-    public Page<Drink> search(DrinkSearchCondition condition, Pageable pageable){
-        List<Drink> content = jpaQueryFactory
-                                .selectFrom(drink)
+    public Page<DrinkSearchResponse> search(DrinkSearchCondition condition, Pageable pageable){
+        List<DrinkSearchResponse> content = jpaQueryFactory
+                                .select(Projections.constructor(DrinkSearchResponse.class,
+                                        drink.id, drink.nameKr, drink.nameEn, drink.manufacturer,
+                                        Expressions.constant(Collections.emptyList()), // 우선 빈 리스트
+                                        Expressions.as(
+                                                Expressions.cases()
+                                                        .when(favorite.id.isNotNull()).then(true)
+                                                        .otherwise(false),
+                                                "isLiked"
+                                        )
+                                ))
+                                .from(drink)
                                 .where(eqName(condition.getNameKr(), condition.getNameEn()),
                                         drink.price.between(condition.getMinPrice(), condition.getMaxPrice()),
                                         eqCategory(condition.getCategoryName()))
                                 .orderBy(drinkSort(pageable))
                                 .offset(pageable.getOffset())
                                 .limit(pageable.getPageSize())
+                                .leftJoin(favorite)
+                                .on(drink.id.eq(favorite.drink.id).and(favorite.member.id.eq(condition.getMemberId())))
+                                .fetchJoin()
                                 .fetch();
 
         JPAQuery<Long> countQuery = jpaQueryFactory

--- a/src/main/java/kuit/project/beering/repository/CustomDrinkRepositoryImpl.java
+++ b/src/main/java/kuit/project/beering/repository/CustomDrinkRepositoryImpl.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import static kuit.project.beering.domain.QDrink.*;
 import static kuit.project.beering.domain.QFavorite.favorite;
+import static kuit.project.beering.domain.image.QDrinkImage.drinkImage;
 
 @Slf4j
 public class CustomDrinkRepositoryImpl implements CustomDrinkRepository {
@@ -55,6 +56,12 @@ public class CustomDrinkRepositoryImpl implements CustomDrinkRepository {
                                 .fetchJoin()
                                 .fetch();
 
+        for (DrinkSearchResponse response : content) {
+            Long drinkId = response.getDrinkId();
+            List<String> imageUrlList = getImageUrlsByDrinkId(drinkId);
+            response.setImageUrlList(imageUrlList);
+        }
+
         JPAQuery<Long> countQuery = jpaQueryFactory
                                     .select(drink.count())
                                     .from(drink)
@@ -64,6 +71,15 @@ public class CustomDrinkRepositoryImpl implements CustomDrinkRepository {
 
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
 
+    }
+
+    private List<String> getImageUrlsByDrinkId(Long drinkId) {
+        List<String> imageUrls = jpaQueryFactory
+                .select(drinkImage.imageUrl)
+                .from(drinkImage)
+                .where(drinkImage.drink.id.eq(drinkId))
+                .fetch();
+        return imageUrls != null ? imageUrls : Collections.emptyList();
     }
 
     private OrderSpecifier<?> drinkSort(Pageable pageable) {

--- a/src/main/java/kuit/project/beering/service/DrinkService.java
+++ b/src/main/java/kuit/project/beering/service/DrinkService.java
@@ -43,38 +43,17 @@ public class DrinkService {
      * @return 검색 결과 10개 // 페이징
      * @exception DrinkException 유효하지 않은 정렬 방식 입력시 예외 발생
      */
-    public Page<DrinkSearchResponse> searchDrinksByName(Long memberId, Integer page, String orderBy, DrinkSearchCondition drinkSearchCondition) {
+    public Page<DrinkSearchResponse> searchDrinksByName(Integer page, String orderBy, DrinkSearchCondition drinkSearchCondition) {
         /**
          * 정렬 적용
          */
 
         Pageable pageable = PageRequest.of(page, SIZE, SortType.getMatchedSort(orderBy));
 
-        Page<Drink> drinkPage = drinkRepository.search(drinkSearchCondition, pageable);
+        Page<DrinkSearchResponse> drinkPage = drinkRepository.search(drinkSearchCondition, pageable);
 
-        List<DrinkSearchResponse> responseList;
-
-        responseList = drinkPage.getContent().stream()
-                        .map(drink -> new DrinkSearchResponse(
-                            drink.getId(),
-                            getTop1DrinkImgUrl(drink),
-                            drink.getNameKr(),
-                            drink.getNameEn(),
-                            drink.getManufacturer(),
-                            isLiked(drink.getId(), memberId)))
-                        .collect(Collectors.toList());
-
-        return new PageImpl<>(responseList, pageable, drinkPage.getTotalElements());
+        return new PageImpl<>(drinkPage.getContent(), pageable, drinkPage.getTotalElements());
     }
-
-    private String getTop1DrinkImgUrl(Drink drink){
-        List<DrinkImage> images = drink.getImages();
-        if(!images.isEmpty()){
-            return images.get(0).getImageUrl();
-        }
-        return null;
-    }
-    
 
     public GetDrinkResponse getDrinkById(Long beerId, Long memberId) {
         log.info("DrinkService.getDrinkById");

--- a/src/main/java/kuit/project/beering/service/DrinkService.java
+++ b/src/main/java/kuit/project/beering/service/DrinkService.java
@@ -63,17 +63,7 @@ public class DrinkService {
         boolean is_liked = favoriteRepository.existsByDrinkIdAndMemberId(drinkId, memberId);
 
         // 리뷰 프리뷰 배열
-        List<Review> reviews = reviewRepository.findTop5ByDrinkIdOrderByCreatedAtDesc(drinkId);
-        List<ReviewPreview> reviewPreviews;
-        reviewPreviews = reviews.stream()
-                .map(review -> new ReviewPreview(
-                        getProfileImageUrl(review),
-                        review.getMember().getNickname(),
-                        review.getContent(),
-                        review.getCreatedAt(),
-                        review.getTotalRating())
-                )
-                .collect(Collectors.toList());
+        List<ReviewPreview> reviewPreviews = getReviewPreviews(drinkId);
 
         return GetDrinkResponse.builder()
                 .beerId(drink.getId())
@@ -88,6 +78,20 @@ public class DrinkService {
                 .isLiked(is_liked)
                 .reviewPreviews(reviewPreviews)
                 .build();
+    }
+
+    private List<ReviewPreview> getReviewPreviews(Long drinkId) {
+        // TODO : 생성순 -> 좋아요순으로 정렬하면 더 좋을 듯.
+        List<Review> reviews = reviewRepository.findTop5ByDrinkIdOrderByCreatedAtDesc(drinkId);
+        return reviews.stream()
+                .map(review -> new ReviewPreview(
+                        getProfileImageUrl(review),
+                        review.getMember().getNickname(),
+                        review.getContent(),
+                        review.getCreatedAt(),
+                        review.getTotalRating())
+                )
+                .collect(Collectors.toList());
     }
 
     private String getProfileImageUrl(Review review){

--- a/src/main/java/kuit/project/beering/service/MemberService.java
+++ b/src/main/java/kuit/project/beering/service/MemberService.java
@@ -3,6 +3,7 @@ package kuit.project.beering.service;
 import kuit.project.beering.domain.image.Image;
 import kuit.project.beering.domain.Member;
 import kuit.project.beering.domain.Status;
+import kuit.project.beering.domain.image.MemberImage;
 import kuit.project.beering.dto.AgreementBulkInsertDto;
 import kuit.project.beering.dto.request.member.MemberLoginRequest;
 import kuit.project.beering.dto.request.member.MemberSignupRequest;
@@ -93,7 +94,6 @@ public class MemberService {
     }
 
     public String getProfileImageUrl(Member member) {
-        Image profileImage = member.getImages().get(0);
-        return profileImage != null ? profileImage.getImageUrl() : null;
+        return member.getImages().size() != 0 ? member.getImages().get(0).getImageUrl() : null;
     }
 }


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링 <!--(no functional changes, no api changes)-->
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 : 

### 작업 동기
<!--
  (Optional)
  작업을 왜 하게 되었는지 서술 (ex : 일관성을 위한 리팩토링)
-->
- 리팩토링
  - 주류 찜 여부 가져오는 거에서 **N+1 문제 발생**
- 기능추가
  - 이미지 1개가 아닌 여러 이미지를 리스트로 가져오도록 기능 추가!

## 변경 사항
<!-- 
  변경 사항 및 관련 이슈에 대해 간단하게 작성
  어떻게보다 무엇을 왜 수정했는지 설명
  (ex : 로그인 시, 카카오 소셜 로그인 기능 추가)
-->
- 주류 찜 리팩토링 
  - Repo의 queryDSL 작성 부분에서.. fetchJoin하여 **N+1 문제** 해결
- 이미지 리스트 검색 기능 추가

### 설명
<!--
  (Optional)
  세부 설명이 필요한 경우 기재
-->
- 이미지 리스트 검색 기능 추가
  - 기존 쿼리에 Image Join하는 부분 추가 시
    - _페이징 엉킴. 결국.. drinkId를 기준으로 페이징처리하는 쿼리를 먼저 쏴서 List<Long> drinkIds 뽑고.._
    - _image 가져 올 쿼리를 따로 작성._
      - _where절로 drinkId 비교하는 방식_
    - _거기에 favorite 쿼리도 따로... _
  - **이거보단..**
     페이징 할 때 favorite 여부 확인 -> 다음에 image 리스트 얻어오는 게 훨씬 코드가 깔끔하고.. 쿼리도 덜 나옴


## 체크리스트
- [x] 무엇을 변경했는지 충분히 설명하고 있나요?
- [x] 새로운 기술을 사용했다면, 그 기술을 설명하고 있나요?
- [x] 이해하기 어려운 비즈니스 로직에 관해서 부연 설명을 하고 있나요?
