### PR TITLE
refactoring Change return type - Page to Slice

### DIFF
--- a/src/main/java/kuit/project/beering/controller/DrinkController.java
+++ b/src/main/java/kuit/project/beering/controller/DrinkController.java
@@ -2,12 +2,14 @@ package kuit.project.beering.controller;
 
 import kuit.project.beering.dto.request.drink.DrinkSearchCondition;
 import kuit.project.beering.dto.response.drink.DrinkSearchResponse;
+import kuit.project.beering.dto.response.drink.DrinkSearchResponsePage;
 import kuit.project.beering.dto.response.drink.GetDrinkResponse;
 import kuit.project.beering.security.auth.AuthMember;
 import kuit.project.beering.util.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import kuit.project.beering.service.DrinkService;
@@ -22,7 +24,7 @@ public class DrinkController {
     private final DrinkService drinkService;
 
     @GetMapping("/search")
-    public BaseResponse<Page<DrinkSearchResponse>> searchDrinksByName(
+    public BaseResponse<DrinkSearchResponsePage> searchDrinksByName(
             @RequestParam(required = false) String name,
             @RequestParam(defaultValue = "0", required = false) Integer page,
             @RequestParam(defaultValue = "name", required = false) String orderBy,
@@ -31,8 +33,12 @@ public class DrinkController {
             @RequestParam(defaultValue = "2147483647", required = false) Integer maxPrice,
             @AuthenticationPrincipal AuthMember member
     ) {
-        Page<DrinkSearchResponse> result = drinkService.searchDrinksByName(page, orderBy, new DrinkSearchCondition(name, name, category, minPrice, maxPrice, member.getId()));
-        return new BaseResponse<>(result);
+        Slice<DrinkSearchResponse> result = drinkService.searchDrinksByName(page, orderBy, new DrinkSearchCondition(name, name, category, minPrice, maxPrice, member.getId()));
+        return new BaseResponse<>(DrinkSearchResponsePage.builder()
+                .drinks(result.getContent())
+                .page(result.getNumber())
+                .isLast(result.isLast())
+                .build());
     }
 
 

--- a/src/main/java/kuit/project/beering/dto/response/drink/DrinkSearchResponsePage.java
+++ b/src/main/java/kuit/project/beering/dto/response/drink/DrinkSearchResponsePage.java
@@ -1,0 +1,17 @@
+package kuit.project.beering.dto.response.drink;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class DrinkSearchResponsePage {
+    List<DrinkSearchResponse> drinks;
+    int page;
+    boolean isLast;
+}

--- a/src/main/java/kuit/project/beering/repository/drink/CustomDrinkRepository.java
+++ b/src/main/java/kuit/project/beering/repository/drink/CustomDrinkRepository.java
@@ -2,12 +2,11 @@ package kuit.project.beering.repository.drink;
 
 import kuit.project.beering.dto.request.drink.DrinkSearchCondition;
 import kuit.project.beering.dto.response.drink.DrinkSearchResponse;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CustomDrinkRepository {
-    Page<DrinkSearchResponse> search(DrinkSearchCondition drinkSearchCondition, Pageable pageable);
-
+    Slice<DrinkSearchResponse> search(DrinkSearchCondition drinkSearchCondition, Pageable pageable);
 }

--- a/src/main/java/kuit/project/beering/repository/drink/CustomDrinkRepositoryImpl.java
+++ b/src/main/java/kuit/project/beering/repository/drink/CustomDrinkRepositoryImpl.java
@@ -5,22 +5,21 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import kuit.project.beering.dto.request.drink.DrinkSearchCondition;
 import kuit.project.beering.dto.response.drink.DrinkSearchResponse;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.util.StringUtils;
 
 import java.util.Collections;
 import java.util.List;
 
-import static kuit.project.beering.domain.QDrink.*;
+import static kuit.project.beering.domain.QDrink.drink;
 import static kuit.project.beering.domain.QFavorite.favorite;
 import static kuit.project.beering.domain.image.QDrinkImage.drinkImage;
 
@@ -32,8 +31,8 @@ public class CustomDrinkRepositoryImpl implements CustomDrinkRepository {
         this.jpaQueryFactory = new JPAQueryFactory(em);
     }
 
-    public Page<DrinkSearchResponse> search(DrinkSearchCondition condition, Pageable pageable){
-        List<DrinkSearchResponse> content = jpaQueryFactory
+    public Slice<DrinkSearchResponse> search(DrinkSearchCondition condition, Pageable pageable){
+        List<DrinkSearchResponse> drinks = jpaQueryFactory
                                 .select(Projections.constructor(DrinkSearchResponse.class,
                                         drink.id, drink.nameKr, drink.nameEn, drink.manufacturer,
                                         Expressions.constant(Collections.emptyList()), // 우선 빈 리스트
@@ -50,26 +49,25 @@ public class CustomDrinkRepositoryImpl implements CustomDrinkRepository {
                                         eqCategory(condition.getCategoryName()))
                                 .orderBy(drinkSort(pageable))
                                 .offset(pageable.getOffset())
-                                .limit(pageable.getPageSize())
+                                .limit(pageable.getPageSize() + 1)
                                 .leftJoin(favorite)
                                 .on(drink.id.eq(favorite.drink.id).and(favorite.member.id.eq(condition.getMemberId())))
                                 .fetchJoin()
                                 .fetch();
 
-        for (DrinkSearchResponse response : content) {
+        for (DrinkSearchResponse response : drinks) {
             Long drinkId = response.getDrinkId();
             List<String> imageUrlList = getImageUrlsByDrinkId(drinkId);
             response.setImageUrlList(imageUrlList);
         }
 
-        JPAQuery<Long> countQuery = jpaQueryFactory
-                                    .select(drink.count())
-                                    .from(drink)
-                                    .where(eqName(condition.getNameKr(), condition.getNameEn()),
-                                            drink.price.between(condition.getMinPrice(), condition.getMaxPrice()),
-                                            eqCategory(condition.getCategoryName()));
+        boolean hasNext = false;
+        if(pageable.getPageSize() < drinks.size()){
+            drinks.remove(pageable.getPageSize());
+            hasNext = true;
+        }
 
-        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+        return new SliceImpl<>(drinks, pageable, hasNext);
 
     }
 

--- a/src/main/java/kuit/project/beering/service/DrinkService.java
+++ b/src/main/java/kuit/project/beering/service/DrinkService.java
@@ -14,10 +14,7 @@ import kuit.project.beering.repository.drink.DrinkRepository;
 import kuit.project.beering.util.exception.DrinkException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -45,16 +42,10 @@ public class DrinkService {
      * @return 검색 결과 10개 // 페이징
      * @exception DrinkException 유효하지 않은 정렬 방식 입력시 예외 발생
      */
-    public Page<DrinkSearchResponse> searchDrinksByName(Integer page, String orderBy, DrinkSearchCondition drinkSearchCondition) {
-        /**
-         * 정렬 적용
-         */
-
+    public Slice<DrinkSearchResponse> searchDrinksByName(Integer page, String orderBy, DrinkSearchCondition drinkSearchCondition) {
         Pageable pageable = PageRequest.of(page, SIZE, SortType.getMatchedSort(orderBy));
 
-        Page<DrinkSearchResponse> drinkPage = drinkRepository.search(drinkSearchCondition, pageable);
-
-        return new PageImpl<>(drinkPage.getContent(), pageable, drinkPage.getTotalElements());
+        return drinkRepository.search(drinkSearchCondition, pageable);
     }
 
     public GetDrinkResponse getDrinkById(Long drinkId, Long memberId) {


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링 <!--(no functional changes, no api changes)-->
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 : 

### 작업 동기
<!--
  (Optional)
  작업을 왜 하게 되었는지 서술 (ex : 일관성을 위한 리팩토링)
-->
1. 프론트 단에서 페이지 방식이 아닌 무한 스크롤 방식을 채택
2. Page<>로 return하는 방식은.. response에 page와 관련된 너무 많은 값이 섞여있음!

## 변경 사항
<!-- 
  변경 사항 및 관련 이슈에 대해 간단하게 작성
  어떻게보다 무엇을 왜 수정했는지 설명
  (ex : 로그인 시, 카카오 소셜 로그인 기능 추가)
-->
1. Page -> Slice로 변경
  - Slice는 지정된 사이즈만큼 반환하고, 다음 페이지가 있는지 없는지만 검사하면 됨! 반면에 Page는 전체 데이터 개수가 몇 개인지도 세는 count query가 추가로 발생됨. 
  - page 방식이 아닌 무한스크롤에서 굳이 Page를 쓸 필요가 없음 -> Slice로 변경
2. Slice의 현재 page 정보와 isLast 정보만 반환하도록 가공


## 체크리스트
- [x] 무엇을 변경했는지 충분히 설명하고 있나요?
- [ ] 새로운 기술을 사용했다면, 그 기술을 설명하고 있나요?
- [ ] 이해하기 어려운 비즈니스 로직에 관해서 부연 설명을 하고 있나요?
