### PR TITLE
리프레시 토큰 탈취 시나리오 관련 보안정책 폐기 + gitignore 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,10 +54,6 @@ out/
 ### VS Code ###
 .vscode/
 
-### Application Properties ###
-/src/main/resources/application.yml
-/src/main/resources/application.properties
-
 ### QType file ###
 /src/main/generated
 

--- a/src/main/java/kuit/project/beering/repository/RefreshTokenRepository.java
+++ b/src/main/java/kuit/project/beering/repository/RefreshTokenRepository.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-@Repository
+//@Repository
 @RequiredArgsConstructor
 public class RefreshTokenRepository {
 

--- a/src/main/java/kuit/project/beering/service/MemberService.java
+++ b/src/main/java/kuit/project/beering/service/MemberService.java
@@ -11,11 +11,9 @@ import kuit.project.beering.dto.response.member.MemberEmailResponse;
 import kuit.project.beering.dto.response.member.MemberInfoResponse;
 import kuit.project.beering.dto.response.member.MemberLoginResponse;
 import kuit.project.beering.dto.response.member.MemberNicknameResponse;
-import kuit.project.beering.redis.RefreshToken;
 import kuit.project.beering.repository.AgreementJdbcRepository;
 import kuit.project.beering.repository.ImageRepository;
 import kuit.project.beering.repository.MemberRepository;
-import kuit.project.beering.repository.RefreshTokenRepository;
 import kuit.project.beering.security.auth.AuthMember;
 import kuit.project.beering.security.jwt.JwtInfo;
 import kuit.project.beering.security.jwt.jwtTokenProvider.BeeringJwtTokenProvider;
@@ -43,7 +41,6 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final AgreementJdbcRepository agreementJdbcRepository;
-    private final RefreshTokenRepository refreshTokenRepository;
     private final ImageRepository imageRepository;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final PasswordEncoder passwordEncoder;
@@ -99,8 +96,6 @@ public class MemberService {
          */
         JwtInfo jwtInfo = beeringJwtTokenProvider.createToken(authentication);
         AuthMember principal = (AuthMember) authentication.getPrincipal();
-
-        refreshTokenRepository.save(new RefreshToken(String.valueOf(principal.getId()), jwtInfo.getRefreshToken()));
 
         return MemberLoginResponse.builder()
                 .memberId(principal.getId())

--- a/src/main/java/kuit/project/beering/service/OAuthService.java
+++ b/src/main/java/kuit/project/beering/service/OAuthService.java
@@ -8,10 +8,8 @@ import kuit.project.beering.dto.common.OAuthMemberInfo;
 import kuit.project.beering.dto.request.auth.OAuthSignupRequest;
 import kuit.project.beering.dto.request.member.MemberSignupRequest;
 import kuit.project.beering.dto.response.member.MemberLoginResponse;
-import kuit.project.beering.redis.RefreshToken;
 import kuit.project.beering.repository.MemberRepository;
 import kuit.project.beering.repository.OAuthRepository;
-import kuit.project.beering.repository.RefreshTokenRepository;
 import kuit.project.beering.security.auth.oauth.service.OAuthClientService;
 import kuit.project.beering.security.jwt.JwtInfo;
 import kuit.project.beering.security.jwt.JwtTokenProviderResolver;
@@ -32,7 +30,6 @@ public class OAuthService {
     private final MemberService memberService;
     private final MemberRepository memberRepository;
     private final OAuthRepository oauthRepository;
-    private final RefreshTokenRepository refreshTokenRepository;
     private final JwtTokenProviderResolver jwtTokenProviderResolver;
 
     @Transactional(noRollbackFor = SignupNotCompletedException.class)
@@ -76,8 +73,6 @@ public class OAuthService {
         // 값 변경
         oauth.tokenReissue(accessToken, refreshToken);
 
-        refreshTokenRepository.save(new RefreshToken(String.valueOf(member.getId()), refreshToken));
-
         return MemberLoginResponse.builder()
                 .memberId(member.getId())
                 .jwtInfo(JwtInfo.builder().accessToken(idToken).refreshToken(refreshToken).build())
@@ -96,8 +91,6 @@ public class OAuthService {
 
         Member member = memberRepository.findByOauthId(oauth.getId()).orElseThrow(
                 () -> new SignupNotCompletedException(sub, oauth.getOauthType()));
-
-        refreshTokenRepository.save(new RefreshToken(String.valueOf(member.getId()), oauthTokenInfo.getRefreshToken()));
 
         return MemberLoginResponse.builder()
                 .memberId(member.getId())

--- a/src/main/java/kuit/project/beering/service/TokenService.java
+++ b/src/main/java/kuit/project/beering/service/TokenService.java
@@ -1,15 +1,10 @@
 package kuit.project.beering.service;
 
-import jakarta.persistence.EntityNotFoundException;
-import kuit.project.beering.domain.Member;
 import kuit.project.beering.dto.request.auth.RefreshTokenRequest;
-import kuit.project.beering.redis.RefreshToken;
 import kuit.project.beering.repository.MemberRepository;
-import kuit.project.beering.repository.RefreshTokenRepository;
 import kuit.project.beering.security.jwt.JwtInfo;
 import kuit.project.beering.security.jwt.JwtTokenProviderResolver;
 import kuit.project.beering.security.jwt.jwtTokenProvider.JwtTokenProvider;
-import kuit.project.beering.util.BaseResponseStatus;
 import kuit.project.beering.util.exception.CustomJwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,7 +18,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class TokenService {
 
     private final MemberRepository memberRepository;
-    private final RefreshTokenRepository refreshTokenRepository;
     private final JwtTokenProviderResolver jwtTokenProviderResolver;
 
     @Transactional(noRollbackFor = CustomJwtException.class)
@@ -33,40 +27,13 @@ public class TokenService {
 
         JwtTokenProvider jwtTokenProvider = jwtTokenProviderResolver.getProvider(refreshToken);
 
+        //todo 리턴값으로 멤버아이디가 필요할까?
         String memberId = jwtTokenProvider.validateRefreshToken(refreshToken);
-
-        validateWithRedis(refreshToken, memberId);
 
         // 3. 액세스 토큰, 리프레시 토큰 재발급
         JwtInfo jwtInfo = jwtTokenProvider.reissueJwtToken(refreshToken);
 
-        if (jwtInfo.getRefreshToken() != null)
-            refreshTokenRepository.save(new RefreshToken(memberId, jwtInfo.getRefreshToken()));
-
         return jwtInfo;
-    }
-
-    /**
-     * @Brief 토큰 검증 - 자체 검증(서명, 만료일 등), redis 비교하여 보안 검증 - 탈취 토큰 사용 감지 시 Member 휴먼으로
-     */
-    private String validateWithRedis(String refreshToken, String memberId) {
-
-        RefreshToken redisRefreshToken = refreshTokenRepository
-                .findById(String.valueOf(memberId))
-                .orElseThrow(() -> new CustomJwtException(BaseResponseStatus.EXPIRED_REFRESH_TOKEN));
-
-        if (!refreshToken.equals(redisRefreshToken.getRefreshToken())) {
-            // 보안 이슈 발생!! -> 사용자 status 변경
-            Member findMember = memberRepository.findById(Long.parseLong(memberId)).orElseThrow(EntityNotFoundException::new);
-            findMember.UpdateStatusToDormant();
-            memberRepository.save(findMember);
-
-            log.error("보안 이슈 발생 memberId = {}", memberId);
-            refreshTokenRepository.delete(refreshToken);
-            throw new CustomJwtException(BaseResponseStatus.USING_STOLEN_TOKEN);
-        }
-
-        return String.valueOf(memberId);
     }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,188 @@
+spring:
+  profiles:
+    group:
+      "local": "localDB, devPort, secret, web-mvc, localRedis"
+      "dev": "devDB, devPort, secret, web-mvc, devRedis"
+      "prod": "prodDB, prodPort, secret, web-mvc, devRedis"
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: "localDB"
+
+  datasource:
+    url: ${DATASOURCE_URL_LOCAL}
+    username: ${DATASOURCE_USERNAME}
+    password: ${DATASOURCE_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    dbcp2:
+      validation-query: select 1
+  sql:
+    init:
+      platform: mysql
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: "devDB"
+
+  datasource:
+    url: ${DATASOURCE_URL_DEV}
+    username: ${DATASOURCE_USERNAME_DEV}
+    password: ${DATASOURCE_PASSWORD_DEV}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    dbcp2:
+      validation-query: select 1
+  sql:
+    init:
+      platform: mysql
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: "prodDB"
+
+  datasource:
+    url: ${DATASOURCE_URL_PROD}
+    username: ${DATASOURCE_USERNAME}
+    password: ${DATASOURCE_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    dbcp2:
+      validation-query: select 1
+  sql:
+    init:
+      platform: mysql
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: "devPort"
+
+server:
+  port: 9000
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: "prodPort"
+
+server:
+  port: 9001
+
+---
+
+secret:
+  jwt-secret-key: ${JWT_SECRET_KEY}
+  jwt-expired-in: ${JWT_EXPIRED_IN} # 60일
+  jwt-refresh-expired-in: ${JWT_REFRESH_EXPIRED_IN} # 60일
+
+  oauth:
+    kakao:
+      token-url: ${KAKAO_TOKEN_URL}
+      api-url: ${KAKAO_API_URL}
+      redirect-url: ${KAKAO_REDIRECT_URL}
+      restapi-key: ${KAKAO_RESTAPI_KEY}
+      admin-key:  ${KAKAO_ADMIN_KEY}
+      client-secret: ${KAKAO_CLIENT_SECRET}
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: "web-mvc"
+
+  #  mvc:
+  #    throw-exception-if-no-handler-found: true
+
+  web:
+    resources:
+      add-mappings: false
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        format_sql: true
+    default_batch_fetch_size: 100
+#  messages:
+#    basename: errors
+
+#  cache:
+#    type: redis
+
+#  data:
+#    redis:
+#      host: localhost
+#      port: 6379
+
+logging.level:
+  org.hibernate.SQL: debug # sql 표시
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: "localRedis"
+
+  cache:
+    type: redis
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: "devRedis"
+
+  cache:
+    type: redis
+
+  data:
+    redis:
+      host: ${EC2_PRIVATE_IP}
+      port: 6379
+
+---
+
+# S3 관련 설정
+cloud:
+  aws:
+    s3:
+      bucket: beering-bucket
+    credentials:
+      access-key: ${S3_ACCESS_KEY}
+      secret-key: ${S3_SECRET_KEY}
+    region:
+      static: ap-northeast-2
+      auto: false
+    stack:
+      auto: false
+
+# multipartFile 용량 늘려주는 설정
+spring:
+  servlet:
+    multipart:
+      max-file-size: 100MB
+      max-request-size: 100MB
+
+
+---


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [x] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링 <!--(no functional changes, no api changes)-->
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 : 

### 작업 동기
<!--
  (Optional)
  작업을 왜 하게 되었는지 서술 (ex : 일관성을 위한 리팩토링)
-->
1. 현재 정책으론 멀티 디바이스 로그인 상황을 고려하지 못함
2. 굳이 할 필요가 없기도 함(jwt 장점인 무상태성 유지가 의미없어짐)

## 변경 사항
<!-- 
  변경 사항 및 관련 이슈에 대해 간단하게 작성
  어떻게보다 무엇을 왜 수정했는지 설명
  (ex : 로그인 시, 카카오 소셜 로그인 기능 추가)
-->
리프레시 토큰을 레디스에 등록하는 과정과 토큰 재발급 시 유저의 리프레시토큰을 레디스와 비교하는 과정 제거
+ gitignore에서 application.yml 파일 제거

### 주안점
<!--
  (Optional)
  리뷰 시에 유심히 봐주었으면 하는 부분 설명
-->

### 설명
<!--
  (Optional)
  세부 설명이 필요한 경우 기재
-->


## 체크리스트
- [x] 무엇을 변경했는지 충분히 설명하고 있나요?
- [x] 새로운 기술을 사용했다면, 그 기술을 설명하고 있나요?
- [x] 이해하기 어려운 비즈니스 로직에 관해서 부연 설명을 하고 있나요?
