### PR TITLE
검색 필터 추가 (하위 옵션 & 태그)

### DIFF
--- a/src/main/java/kuit/project/beering/controller/FavoriteController.java
+++ b/src/main/java/kuit/project/beering/controller/FavoriteController.java
@@ -38,13 +38,13 @@ public class FavoriteController {
     }
 
     @GetMapping("/members/{memberId}/favorites")
-    public BaseResponse<SliceResponse<GetFavoriteDrinkResponse>> getFavoriteReviews(
+    public BaseResponse<SliceResponse<GetFavoriteDrinkResponse>> getFavoriteDrinks(
             @PathVariable Long memberId,
             @RequestParam(required = false, defaultValue = "0") int page,
             @AuthenticationPrincipal AuthMember member) {
 
         validateMember(member.getId(), memberId);
-        Slice<GetFavoriteDrinkResponse> result = favoriteService.getFavoriteReviews(memberId, PageRequest.of(page, SIZE));
+        Slice<GetFavoriteDrinkResponse> result = favoriteService.getFavoriteDrinks(memberId, PageRequest.of(page, SIZE));
 
         return new BaseResponse<>(new SliceResponse<>(result));
     }

--- a/src/main/java/kuit/project/beering/domain/Beer.java
+++ b/src/main/java/kuit/project/beering/domain/Beer.java
@@ -6,5 +6,4 @@ import jakarta.persistence.Entity;
 @Entity
 @DiscriminatorValue("beer")
 public class Beer extends Drink{
-        private String country;
 }

--- a/src/main/java/kuit/project/beering/domain/Drink.java
+++ b/src/main/java/kuit/project/beering/domain/Drink.java
@@ -44,9 +44,6 @@ public class Drink extends BaseTimeEntity{
     @Column(nullable = false)
     private String manufacturer;
 
-    // TODO : country table 논의
-    @Column(nullable = true)
-    private String country;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/java/kuit/project/beering/domain/Drink.java
+++ b/src/main/java/kuit/project/beering/domain/Drink.java
@@ -44,6 +44,10 @@ public class Drink extends BaseTimeEntity{
     @Column(nullable = false)
     private String manufacturer;
 
+    // TODO : country table 논의
+    @Column(nullable = true)
+    private String country;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Status status;

--- a/src/main/java/kuit/project/beering/domain/Drink.java
+++ b/src/main/java/kuit/project/beering/domain/Drink.java
@@ -49,6 +49,9 @@ public class Drink extends BaseTimeEntity{
     @Column(nullable = false)
     private Status status;
 
+    @Column(nullable = false)
+    private String country;
+
     //연관관계 mapping
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id")

--- a/src/main/java/kuit/project/beering/domain/Wine.java
+++ b/src/main/java/kuit/project/beering/domain/Wine.java
@@ -4,7 +4,8 @@ import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 
 @Entity
-@DiscriminatorValue("beer")
-public class Beer extends Drink{
-        private String country;
+@DiscriminatorValue("wine")
+public class Wine extends Drink{
+    private int sweetness;
+    private String country;
 }

--- a/src/main/java/kuit/project/beering/domain/Wine.java
+++ b/src/main/java/kuit/project/beering/domain/Wine.java
@@ -7,5 +7,4 @@ import jakarta.persistence.Entity;
 @DiscriminatorValue("wine")
 public class Wine extends Drink{
     private int sweetness;
-    private String country;
 }

--- a/src/main/java/kuit/project/beering/dto/request/drink/DrinkSearchCondition.java
+++ b/src/main/java/kuit/project/beering/dto/request/drink/DrinkSearchCondition.java
@@ -14,5 +14,7 @@ public class DrinkSearchCondition {
     Integer minPrice;
     Integer maxPrice;
     List<String> tags;
+    String country;
+    Integer sweetness;
     Long memberId;
 }

--- a/src/main/java/kuit/project/beering/dto/request/drink/DrinkSearchCondition.java
+++ b/src/main/java/kuit/project/beering/dto/request/drink/DrinkSearchCondition.java
@@ -13,5 +13,6 @@ public class DrinkSearchCondition {
     List<String> categories;
     Integer minPrice;
     Integer maxPrice;
+    List<String> tags;
     Long memberId;
 }

--- a/src/main/java/kuit/project/beering/dto/request/drink/SearchDrinkRequest.java
+++ b/src/main/java/kuit/project/beering/dto/request/drink/SearchDrinkRequest.java
@@ -18,5 +18,7 @@ public class SearchDrinkRequest {
     private List<String> category;
     private Integer minPrice = 0;
     private Integer maxPrice = Integer.MAX_VALUE;
+    private String country;
+    private Integer sweetness;
     private List<String> tag;
 }

--- a/src/main/java/kuit/project/beering/dto/request/drink/SearchDrinkRequest.java
+++ b/src/main/java/kuit/project/beering/dto/request/drink/SearchDrinkRequest.java
@@ -18,4 +18,5 @@ public class SearchDrinkRequest {
     private List<String> category;
     private Integer minPrice = 0;
     private Integer maxPrice = Integer.MAX_VALUE;
+    private List<String> tag;
 }

--- a/src/main/java/kuit/project/beering/dto/response/drink/DrinkSearchResponse.java
+++ b/src/main/java/kuit/project/beering/dto/response/drink/DrinkSearchResponse.java
@@ -16,6 +16,8 @@ public class DrinkSearchResponse {
     String nameKr;
     String nameEn;
     String manufacturer;
+    Float avgRating;
+    Integer countOfReview;
     List<String> imageUrlList;
     Boolean isLiked;
 }

--- a/src/main/java/kuit/project/beering/dto/response/drink/GetDrinkResponse.java
+++ b/src/main/java/kuit/project/beering/dto/response/drink/GetDrinkResponse.java
@@ -19,6 +19,7 @@ public class GetDrinkResponse {
     float alcohol;
     String description;
     String manufacturer;
+    String country;
     float totalRating;
     int reviewCount;
     boolean isLiked;

--- a/src/main/java/kuit/project/beering/dto/response/drink/GetDrinkResponseBuilder.java
+++ b/src/main/java/kuit/project/beering/dto/response/drink/GetDrinkResponseBuilder.java
@@ -1,5 +1,6 @@
 package kuit.project.beering.dto.response.drink;
 
+import kuit.project.beering.domain.Beer;
 import kuit.project.beering.domain.Drink;
 import kuit.project.beering.domain.image.DrinkImage;
 import kuit.project.beering.domain.image.Image;
@@ -23,6 +24,7 @@ public class GetDrinkResponseBuilder implements ResponseBuilder<GetDrinkResponse
                 .alcohol(drink.getAlcohol())
                 .description(drink.getDescription())
                 .manufacturer(drink.getManufacturer())
+                .country(drink.getCountry())
                 .totalRating(drink.getAvgRating())
                 .reviewCount(drink.getCountOfReview())
                 .isLiked(isLiked)

--- a/src/main/java/kuit/project/beering/dto/response/favorite/GetFavoriteDrinkResponse.java
+++ b/src/main/java/kuit/project/beering/dto/response/favorite/GetFavoriteDrinkResponse.java
@@ -15,4 +15,7 @@ public class GetFavoriteDrinkResponse {
     String nameEn;
     String manufacturer;
     String primaryImageUrl;
+    String country;
+    Float avgRating;
+    Integer countOfReview;
 }

--- a/src/main/java/kuit/project/beering/repository/drink/CustomDrinkRepositoryImpl.java
+++ b/src/main/java/kuit/project/beering/repository/drink/CustomDrinkRepositoryImpl.java
@@ -7,7 +7,6 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
-import kuit.project.beering.domain.Beer;
 import kuit.project.beering.domain.Wine;
 import kuit.project.beering.dto.request.drink.DrinkSearchCondition;
 import kuit.project.beering.dto.response.drink.DrinkSearchResponse;
@@ -21,7 +20,6 @@ import org.springframework.util.StringUtils;
 import java.util.Collections;
 import java.util.List;
 
-import static kuit.project.beering.domain.QBeer.beer;
 import static kuit.project.beering.domain.QDrink.drink;
 import static kuit.project.beering.domain.QDrinkTag.drinkTag;
 import static kuit.project.beering.domain.QFavorite.favorite;
@@ -63,7 +61,6 @@ public class CustomDrinkRepositoryImpl implements CustomDrinkRepository {
                                 .leftJoin(favorite)
                                 .on(drink.id.eq(favorite.drink.id).and(favorite.member.id.eq(condition.getMemberId())))
                                 .leftJoin(wine).on(drink.id.eq(wine.id).and(drink.instanceOf(Wine.class)))
-                                .leftJoin(beer).on(drink.id.eq(beer.id).and(drink.instanceOf(Beer.class)))
                                 .fetchJoin()
                                 .fetch();
 
@@ -118,8 +115,7 @@ public class CustomDrinkRepositoryImpl implements CustomDrinkRepository {
     private BooleanExpression eqCountry(String country) {
         if(!StringUtils.hasText(country))
             return null;
-
-        return wine.country.eq(country).or(beer.country.eq(country));
+        return drink.country.eq(country);
     }
 
     private BooleanExpression eqTags(List<String> tags) {

--- a/src/main/java/kuit/project/beering/service/DrinkService.java
+++ b/src/main/java/kuit/project/beering/service/DrinkService.java
@@ -52,7 +52,8 @@ public class DrinkService {
         Pageable pageable = PageRequest.of(request.getPage(), SIZE, SortType.getMatchedSort(request.getOrderBy()));
 
         DrinkSearchCondition drinkSearchCondition = new DrinkSearchCondition(
-                request.getName(), request.getName(), request.getCategory(), request.getMinPrice(), request.getMaxPrice(), request.getTag(), memberId);
+                request.getName(), request.getName(), request.getCategory(), request.getMinPrice(), request.getMaxPrice(),
+                request.getTag(), request.getCountry(), request.getSweetness(), memberId);
 
         return drinkRepository.search(drinkSearchCondition, pageable);
     }

--- a/src/main/java/kuit/project/beering/service/DrinkService.java
+++ b/src/main/java/kuit/project/beering/service/DrinkService.java
@@ -39,20 +39,23 @@ public class DrinkService {
 
     private final int SIZE = 10;
 
-//    /**
-//     * 주류 검색 메소드 <br>
-//     * <br>
-//     * @param page 페이지 번호
-//     * @param orderBy 정렬 : 이름순, 리뷰많은순, 최저가순, 평점순
-//     * @param drinkSearchCondition 필터 : 이름, 카테고리이름, 하한선, 상한선
-//     * @return 검색 결과 10개 // 페이징
-//     * @exception DrinkException 유효하지 않은 정렬 방식 입력시 예외 발생
-//     */
-//    public Slice<DrinkSearchResponse> searchDrinksByName(Integer page, String orderBy, DrinkSearchCondition drinkSearchCondition) {
-//        Pageable pageable = PageRequest.of(page, SIZE, SortType.getMatchedSort(orderBy));
-//
-//        return drinkRepository.search(drinkSearchCondition, pageable);
-//    }
+    /**
+     * 주류 검색 메소드 <br>
+     * <br>
+     * page 페이지 번호<br>
+     * orderBy 정렬 : 이름순, 리뷰많은순, 최저가순, 평점순<br>
+     * drinkSearchCondition 필터 : 이름, 카테고리이름, 하한선, 상한선<br>
+     * @return 검색 결과 10개 // 페이징
+     * @exception DrinkException 유효하지 않은 정렬 방식 입력시 예외 발생
+     */
+    public Slice<DrinkSearchResponse> searchDrinksByName(SearchDrinkRequest request, Long memberId) {
+        Pageable pageable = PageRequest.of(request.getPage(), SIZE, SortType.getMatchedSort(request.getOrderBy()));
+
+        DrinkSearchCondition drinkSearchCondition = new DrinkSearchCondition(
+                request.getName(), request.getName(), request.getCategory(), request.getMinPrice(), request.getMaxPrice(), request.getTag(), memberId);
+
+        return drinkRepository.search(drinkSearchCondition, pageable);
+    }
 
     @Transactional
     public GetDrinkResponse getDrinkById(Long drinkId, Long memberId) {
@@ -74,7 +77,6 @@ public class DrinkService {
     }
 
     private List<ReviewPreview> getReviewPreviews(Long drinkId) {
-        // TODO : 생성순 -> 좋아요순으로 정렬하면 더 좋을 듯.
         List<Review> reviews = reviewRepository.findTop5ByDrinkIdOrderByTabomsDesc(drinkId);
         return reviews.stream()
                 .map(review -> new ReviewPreview(
@@ -92,13 +94,4 @@ public class DrinkService {
         return memberService.getProfileImageUrl(member);
     }
 
-
-    public Slice<DrinkSearchResponse> searchDrinksByName(SearchDrinkRequest request, Long memberId) {
-        Pageable pageable = PageRequest.of(request.getPage(), SIZE, SortType.getMatchedSort(request.getOrderBy()));
-
-        DrinkSearchCondition drinkSearchCondition = new DrinkSearchCondition(
-                request.getName(), request.getName(), request.getCategory(), request.getMinPrice(), request.getMaxPrice(), memberId);
-
-        return drinkRepository.search(drinkSearchCondition, pageable);
-    }
 }

--- a/src/main/java/kuit/project/beering/service/FavoriteService.java
+++ b/src/main/java/kuit/project/beering/service/FavoriteService.java
@@ -73,6 +73,9 @@ public class FavoriteService {
                 .nameKr(drink.getNameKr())
                 .manufacturer(drink.getManufacturer())
                 .primaryImageUrl(getPrimaryImage(drink))
+                .avgRating(drink.getAvgRating())
+                .country(drink.getCountry())
+                .countOfReview(drink.getCountOfReview())
                 .build();
     }
 

--- a/src/main/java/kuit/project/beering/service/FavoriteService.java
+++ b/src/main/java/kuit/project/beering/service/FavoriteService.java
@@ -53,7 +53,7 @@ public class FavoriteService {
     }
 
     @Transactional
-    public Slice<GetFavoriteDrinkResponse> getFavoriteReviews(Long memberId, Pageable pageable) {
+    public Slice<GetFavoriteDrinkResponse> getFavoriteDrinks(Long memberId, Pageable pageable) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(NONE_MEMBER));
 

--- a/src/main/java/kuit/project/beering/util/BaseResponseStatus.java
+++ b/src/main/java/kuit/project/beering/util/BaseResponseStatus.java
@@ -69,6 +69,8 @@ public enum BaseResponseStatus {
     // 2100 : DrinkException
     NONE_DRINK(false, 2100, "해당 주류가 존재하지 않습니다."),
     INVALID_ORDER(false, 2101, "유효하지 않은 정렬방식 입니다."),
+    INVALID_SUB_OPTION(false, 2102, "유효하지 않은 하위 옵션(들)입니다."),
+    UNSUPPORTED_SUB_OPTION(false, 2103, "하위 옵션을 제공하지 않습니다."),
 
 
     // 2200 : FavoriteException


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링 <!--(no functional changes, no api changes)-->
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 : 

### 작업 동기
<!--
  (Optional)
  작업을 왜 하게 되었는지 서술 (ex : 일관성을 위한 리팩토링)
-->
주류 검색 필터를 추가했습니다.

## 변경 사항
<!-- 
  변경 사항 및 관련 이슈에 대해 간단하게 작성
  어떻게보다 무엇을 왜 수정했는지 설명
  (ex : 로그인 시, 카카오 소셜 로그인 기능 추가)
-->
주류 검색 필터에서
1. 하위 옵션에 따른 검색 기능 추가 (ex : 와인-당도)
   - 와인 domain도 추가했습니다.
2. 태그에 따른 검색 기능 추가 (다중 검색 가능)
   - 태그 목록을 넘겨주는 api도 작성되어야 합니다! (태그 기능 pull 후 진행 예정)
3. 자잘하게 바뀐 response 명세에 맞게 자잘 수정

### 주안점
<!--
  (Optional)
  리뷰 시에 유심히 봐주었으면 하는 부분 설명
-->
하위 옵션의 경우 서버에서 하위 옵션 리스트를 넘겨주지 않고, 프론트에서 관리될 수 있게 작성하였습니다.
따라서 서버측에선 예외처리만 진행합니다.

### 설명
<!--
  (Optional)
  세부 설명이 필요한 경우 기재
-->


## 체크리스트
- [x] 무엇을 변경했는지 충분히 설명하고 있나요?
- [ ] 새로운 기술을 사용했다면, 그 기술을 설명하고 있나요?
- [ ] 이해하기 어려운 비즈니스 로직에 관해서 부연 설명을 하고 있나요?
