### PR TITLE
모든 태그 및 태그 정보 가져오기 API 추가 

### DIFF
--- a/src/main/java/kuit/project/beering/configuration/SecurityConfig.java
+++ b/src/main/java/kuit/project/beering/configuration/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
                         sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorizeRequest -> {
                     authorizeRequest.requestMatchers("/", "/auth/**", "/oauth/**","/members",
-                            "/members/validate/**","/drinks/**", "/error", "/reviews/**", "/reviewOptions/**").permitAll();
+                            "/members/validate/**","/drinks/**", "/error", "/reviews/**", "/reviewOptions/**", "/tags/**").permitAll();
                 })
                 .authorizeHttpRequests(authorizeRequest -> authorizeRequest.anyRequest().authenticated())
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProviderResolver), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/kuit/project/beering/controller/TagController.java
+++ b/src/main/java/kuit/project/beering/controller/TagController.java
@@ -2,6 +2,7 @@ package kuit.project.beering.controller;
 
 import kuit.project.beering.dto.response.drink.GetDrinkResponse;
 import kuit.project.beering.dto.response.tag.GetTagDetailResponse;
+import kuit.project.beering.dto.response.tag.GetTagResponse;
 import kuit.project.beering.service.TagService;
 import kuit.project.beering.util.BaseResponse;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +14,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 import static kuit.project.beering.util.BaseResponseStatus.NONE_TAG;
 
 @RestController
@@ -23,6 +26,18 @@ public class TagController {
 
     private static final Logger logger = LoggerFactory.getLogger(TagController.class);
     private final TagService tagService;
+
+    /**
+     * 모든 태그를 받아오는 API
+     * @return BaseResponse<List<GetTagResponse>>
+     */
+    @GetMapping("/tags")
+    public BaseResponse<List<GetTagResponse>> getAllTags() {
+
+        List<GetTagResponse> getTagResponses = tagService.getAllTags();
+
+        return new BaseResponse<>(getTagResponses);
+    }
 
     /**
      * tagId 를 받아, 해당 tag 의 description return

--- a/src/main/java/kuit/project/beering/controller/TagController.java
+++ b/src/main/java/kuit/project/beering/controller/TagController.java
@@ -1,0 +1,43 @@
+package kuit.project.beering.controller;
+
+import kuit.project.beering.dto.response.drink.GetDrinkResponse;
+import kuit.project.beering.dto.response.tag.GetTagDetailResponse;
+import kuit.project.beering.service.TagService;
+import kuit.project.beering.util.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static kuit.project.beering.util.BaseResponseStatus.NONE_TAG;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping
+public class TagController {
+
+    private static final Logger logger = LoggerFactory.getLogger(TagController.class);
+    private final TagService tagService;
+
+    /**
+     * tagId 를 받아, 해당 tag 의 description return
+     */
+    @GetMapping("/tags/{tagId}")
+    public BaseResponse<GetTagDetailResponse> getTagDetail(@PathVariable Long tagId){
+
+        logger.info("[tagId] : " + tagId);
+
+        GetTagDetailResponse getTagDetailResponse = tagService.getTagDetail(tagId);
+
+        if (getTagDetailResponse == null) {
+            return new BaseResponse<>(NONE_TAG);
+        }
+        return new BaseResponse<>(getTagDetailResponse);
+    }
+
+}

--- a/src/main/java/kuit/project/beering/controller/TagController.java
+++ b/src/main/java/kuit/project/beering/controller/TagController.java
@@ -1,6 +1,5 @@
 package kuit.project.beering.controller;
 
-import kuit.project.beering.dto.response.drink.GetDrinkResponse;
 import kuit.project.beering.dto.response.tag.GetTagDetailResponse;
 import kuit.project.beering.dto.response.tag.GetTagResponse;
 import kuit.project.beering.service.TagService;
@@ -15,8 +14,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-
-import static kuit.project.beering.util.BaseResponseStatus.NONE_TAG;
 
 @RestController
 @RequiredArgsConstructor
@@ -49,9 +46,6 @@ public class TagController {
 
         GetTagDetailResponse getTagDetailResponse = tagService.getTagDetail(tagId);
 
-        if (getTagDetailResponse == null) {
-            return new BaseResponse<>(NONE_TAG);
-        }
         return new BaseResponse<>(getTagDetailResponse);
     }
 

--- a/src/main/java/kuit/project/beering/dto/response/tag/GetTagDetailResponse.java
+++ b/src/main/java/kuit/project/beering/dto/response/tag/GetTagDetailResponse.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class GetTagDetailResponse {
-//    Long tagId;
+    Long tagId;
     String tagName;
     String description;
 }

--- a/src/main/java/kuit/project/beering/dto/response/tag/GetTagDetailResponse.java
+++ b/src/main/java/kuit/project/beering/dto/response/tag/GetTagDetailResponse.java
@@ -1,0 +1,12 @@
+package kuit.project.beering.dto.response.tag;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetTagDetailResponse {
+//    Long tagId;
+    String tagName;
+    String description;
+}

--- a/src/main/java/kuit/project/beering/dto/response/tag/GetTagResponse.java
+++ b/src/main/java/kuit/project/beering/dto/response/tag/GetTagResponse.java
@@ -1,0 +1,11 @@
+package kuit.project.beering.dto.response.tag;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetTagResponse {
+    Long tagId;
+    String tagName;
+}

--- a/src/main/java/kuit/project/beering/repository/TagRepository.java
+++ b/src/main/java/kuit/project/beering/repository/TagRepository.java
@@ -1,0 +1,7 @@
+package kuit.project.beering.repository;
+
+import kuit.project.beering.domain.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+}

--- a/src/main/java/kuit/project/beering/service/TagService.java
+++ b/src/main/java/kuit/project/beering/service/TagService.java
@@ -25,11 +25,11 @@ public class TagService {
             Tag tag = result.get();
 
             return GetTagDetailResponse.builder()
+                    .tagId(tag.getId())
                     .tagName(tag.getValue())
                     .description(tag.getDescription())
                     .build();
         }
-
         return null;
     }
 

--- a/src/main/java/kuit/project/beering/service/TagService.java
+++ b/src/main/java/kuit/project/beering/service/TagService.java
@@ -2,13 +2,16 @@ package kuit.project.beering.service;
 
 import kuit.project.beering.domain.Tag;
 import kuit.project.beering.dto.response.tag.GetTagDetailResponse;
+import kuit.project.beering.dto.response.tag.GetTagResponse;
 import kuit.project.beering.repository.TagRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +20,15 @@ import java.util.Optional;
 public class TagService {
 
     private final TagRepository tagRepository;
+
+    public List<GetTagResponse> getAllTags() {
+        return tagRepository.findAll().stream()
+                .map(tag -> GetTagResponse.builder()
+                        .tagId(tag.getId())
+                        .tagName(tag.getValue())
+                        .build())
+                .collect(Collectors.toList());
+    }
 
     public GetTagDetailResponse getTagDetail(Long tagId) {
         Optional<Tag> result = tagRepository.findById(tagId);

--- a/src/main/java/kuit/project/beering/service/TagService.java
+++ b/src/main/java/kuit/project/beering/service/TagService.java
@@ -4,14 +4,16 @@ import kuit.project.beering.domain.Tag;
 import kuit.project.beering.dto.response.tag.GetTagDetailResponse;
 import kuit.project.beering.dto.response.tag.GetTagResponse;
 import kuit.project.beering.repository.TagRepository;
+import kuit.project.beering.util.exception.domain.TagException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
+
+import static kuit.project.beering.util.BaseResponseStatus.NONE_TAG;
 
 @Service
 @RequiredArgsConstructor
@@ -31,18 +33,14 @@ public class TagService {
     }
 
     public GetTagDetailResponse getTagDetail(Long tagId) {
-        Optional<Tag> result = tagRepository.findById(tagId);
+        Tag tag = tagRepository.findById(tagId)
+                .orElseThrow(() -> new TagException(NONE_TAG));
 
-        if (result.isPresent()) {
-            Tag tag = result.get();
-
-            return GetTagDetailResponse.builder()
-                    .tagId(tag.getId())
-                    .tagName(tag.getValue())
-                    .description(tag.getDescription())
-                    .build();
-        }
-        return null;
+        return GetTagDetailResponse.builder()
+                .tagId(tag.getId())
+                .tagName(tag.getValue())
+                .description(tag.getDescription())
+                .build();
     }
 
 }

--- a/src/main/java/kuit/project/beering/service/TagService.java
+++ b/src/main/java/kuit/project/beering/service/TagService.java
@@ -1,0 +1,36 @@
+package kuit.project.beering.service;
+
+import kuit.project.beering.domain.Tag;
+import kuit.project.beering.dto.response.tag.GetTagDetailResponse;
+import kuit.project.beering.repository.TagRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class TagService {
+
+    private final TagRepository tagRepository;
+
+    public GetTagDetailResponse getTagDetail(Long tagId) {
+        Optional<Tag> result = tagRepository.findById(tagId);
+
+        if (result.isPresent()) {
+            Tag tag = result.get();
+
+            return GetTagDetailResponse.builder()
+                    .tagName(tag.getValue())
+                    .description(tag.getDescription())
+                    .build();
+        }
+
+        return null;
+    }
+
+}

--- a/src/main/java/kuit/project/beering/util/BaseResponseStatus.java
+++ b/src/main/java/kuit/project/beering/util/BaseResponseStatus.java
@@ -80,6 +80,10 @@ public enum BaseResponseStatus {
     // 2300 : TabomException
     POST_TABOM_ALREADY_CREATED(false, 2300, "이미 좋아요나 싫어요가 존재합니다."),
 
+    // 2400 : TagException
+    NONE_TAG(false, 2400, "해당 태그가 존재하지 않습니다."),
+
+
     /**
      * 3000 : Response 오류
      */

--- a/src/main/java/kuit/project/beering/util/exception/domain/TagException.java
+++ b/src/main/java/kuit/project/beering/util/exception/domain/TagException.java
@@ -1,0 +1,15 @@
+package kuit.project.beering.util.exception.domain;
+
+import kuit.project.beering.util.BaseResponseStatus;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Getter
+@Slf4j
+public class TagException extends DomainException {
+
+    public TagException(BaseResponseStatus status) {
+        super(status);
+        log.info("{} - message : {}", this.getClass().getSimpleName(), status.getResponseMessage());
+    }
+}


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 : 

### 작업 동기
태그 관련 API 추가

## 변경 사항
- 태그 상세보기
화면에 들어가는 태그 에 대한 상세정보 (tagId 에 해당하는 tagName 과 description return) API 추가
태그 상세정보에서 표시되는 태그 기반 주류 리스트는, 주류 검색 API 를 사용할 것이라 구현 X
- 모든 태그 받아오기
주류 검색 필터에서 표시할 모든 주류 태그 반환하는 API 추가

### 주안점
전반적인 구조..?

### 설명
위와 같음

## 체크리스트
- [x] 무엇을 변경했는지 충분히 설명하고 있나요?
- [x] 새로운 기술을 사용했다면, 그 기술을 설명하고 있나요?
- [x] 이해하기 어려운 비즈니스 로직에 관해서 부연 설명을 하고 있나요?
