### PR TITLE
인증/인가 플로우 수정

### DIFF
--- a/src/main/java/kuit/project/beering/configuration/SecurityConfig.java
+++ b/src/main/java/kuit/project/beering/configuration/SecurityConfig.java
@@ -1,5 +1,6 @@
 package kuit.project.beering.configuration;
 
+import kuit.project.beering.domain.Role;
 import kuit.project.beering.security.filter.JwtAuthenticationFilter;
 import kuit.project.beering.security.filter.JwtExceptionFilter;
 import kuit.project.beering.security.jwt.jwtTokenProvider.JwtTokenProvider;
@@ -40,7 +41,7 @@ public class SecurityConfig {
                     authorizeRequest.requestMatchers("/", "/auth/**", "/oauth/**","/members",
                             "/members/validate/**","/drinks/**", "/error", "/reviews/**", "/reviewOptions/**").permitAll();
                 })
-                .authorizeHttpRequests(authorizeRequest -> authorizeRequest.anyRequest().hasRole("MEMBER"))
+                .authorizeHttpRequests(authorizeRequest -> authorizeRequest.anyRequest().hasRole(Role.MEMBER.getValue()))
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new JwtExceptionFilter(), JwtAuthenticationFilter.class);
 

--- a/src/main/java/kuit/project/beering/configuration/SecurityConfig.java
+++ b/src/main/java/kuit/project/beering/configuration/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
                     authorizeRequest.requestMatchers("/", "/auth/**", "/oauth/**","/members",
                             "/members/validate/**","/drinks/**", "/error", "/reviews/**", "/reviewOptions/**").permitAll();
                 })
-                .authorizeHttpRequests(authorizeRequest -> authorizeRequest.anyRequest().authenticated())
+                .authorizeHttpRequests(authorizeRequest -> authorizeRequest.anyRequest().hasRole("MEMBER"))
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new JwtExceptionFilter(), JwtAuthenticationFilter.class);
 

--- a/src/main/java/kuit/project/beering/controller/AuthController.java
+++ b/src/main/java/kuit/project/beering/controller/AuthController.java
@@ -64,7 +64,10 @@ public class AuthController {
      * @return
      */
     @PostMapping("/token")
-    public BaseResponse<JwtInfo> reissueToken(@RequestBody RefreshTokenRequest refreshToken) {
+    public BaseResponse<JwtInfo> reissueToken(@RequestBody @Validated RefreshTokenRequest refreshToken, BindingResult bindingResult) {
+
+        if (bindingResult.hasErrors()) throw new FieldValidationException(bindingResult);
+
         JwtInfo jwtInfo = tokenService.reissueToken(refreshToken);
 
         return new BaseResponse<>(jwtInfo);

--- a/src/main/java/kuit/project/beering/domain/RecordAmount.java
+++ b/src/main/java/kuit/project/beering/domain/RecordAmount.java
@@ -13,10 +13,10 @@ public class RecordAmount extends BaseTimeEntity{
     @Column(name = "record_amount_id")
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "smallint")
     private Integer volume;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "tinyint")
     private Integer quantity;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/kuit/project/beering/domain/Role.java
+++ b/src/main/java/kuit/project/beering/domain/Role.java
@@ -1,5 +1,25 @@
 package kuit.project.beering.domain;
 
 public enum Role {
-    MEMBER, ADMIN
+
+    GUEST("GUEST"),
+    MEMBER("MEMBER"),
+    ADMIN("ADMIN");
+
+    Role(String value) {
+        this.value = value;
+        this.role = PREFIX + value;
+    }
+
+    private final String PREFIX = "ROLE_";
+    private final String value;
+    private final String role;
+
+    public String getValue() {
+        return value;
+    }
+
+    public String getRole() {
+        return role;
+    }
 }

--- a/src/main/java/kuit/project/beering/dto/request/auth/RefreshTokenRequest.java
+++ b/src/main/java/kuit/project/beering/dto/request/auth/RefreshTokenRequest.java
@@ -1,5 +1,6 @@
 package kuit.project.beering.dto.request.auth;
 
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -9,5 +10,6 @@ import lombok.Setter;
 @NoArgsConstructor
 public class RefreshTokenRequest {
 
+    @Pattern(regexp = "Bearer .*", message = "Refresh token should start with 'Bearer '")
     private String refreshToken;
 }

--- a/src/main/java/kuit/project/beering/security/auth/AuthMember.java
+++ b/src/main/java/kuit/project/beering/security/auth/AuthMember.java
@@ -1,23 +1,25 @@
 package kuit.project.beering.security.auth;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
 import java.util.List;
 
 @Getter
-@AllArgsConstructor
-@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
 public class AuthMember implements UserDetails {
 
-    private Long id;
-    private String username;
-    private String password;
-    private List<GrantedAuthority> authorities;
+    private final Long id;
+    private final String username;
+    private final String password;
+    private final List<GrantedAuthority> authorities;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
@@ -53,4 +55,23 @@ public class AuthMember implements UserDetails {
     public boolean isEnabled() {
         return true;
     }
+
+    public static AuthMember GUEST(List<GrantedAuthority> authorities) {
+        return AuthMember.builder()
+                .id(0L)
+                .username("")
+                .password("")
+                .authorities(authorities)
+                .build();
+    }
+
+    public static AuthMember MEMBER(Long id, String username, List<GrantedAuthority> authorities) {
+        return AuthMember.builder()
+                .id(id)
+                .username(username)
+                .password("")
+                .authorities(authorities)
+                .build();
+    }
+
 }

--- a/src/main/java/kuit/project/beering/security/auth/AuthMember.java
+++ b/src/main/java/kuit/project/beering/security/auth/AuthMember.java
@@ -1,5 +1,6 @@
 package kuit.project.beering.security.auth;
 
+import kuit.project.beering.domain.Role;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -74,13 +75,21 @@ public class AuthMember implements UserDetails {
                 .build();
     }
 
+    public static AuthMember MEMBER(Long id, String username, String password, List<GrantedAuthority> authorities) {
+        return AuthMember.builder()
+                .id(id)
+                .username(username)
+                .password(password)
+                .authorities(authorities)
+                .build();
+    }
+
     public boolean isGuest() {
-        return authorities.contains(new SimpleGrantedAuthority("ROLE_GUEST"));
+        return authorities.contains(new SimpleGrantedAuthority(Role.GUEST.getRole()));
     }
 
     public boolean isMember() {
-        return authorities.contains(new SimpleGrantedAuthority("ROLE_MEMBER"));
+        return authorities.contains(new SimpleGrantedAuthority(Role.MEMBER.getRole()));
     }
-
 
 }

--- a/src/main/java/kuit/project/beering/security/auth/AuthMember.java
+++ b/src/main/java/kuit/project/beering/security/auth/AuthMember.java
@@ -74,4 +74,13 @@ public class AuthMember implements UserDetails {
                 .build();
     }
 
+    public boolean isGuest() {
+        return authorities.contains(new SimpleGrantedAuthority("ROLE_GUEST"));
+    }
+
+    public boolean isMember() {
+        return authorities.contains(new SimpleGrantedAuthority("ROLE_MEMBER"));
+    }
+
+
 }

--- a/src/main/java/kuit/project/beering/security/auth/AuthenticationProviderImpl.java
+++ b/src/main/java/kuit/project/beering/security/auth/AuthenticationProviderImpl.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
@@ -26,11 +27,10 @@ public class AuthenticationProviderImpl implements AuthenticationProvider {
     public Authentication authenticate(Authentication authentication) {
         log.info("AuthenticationProviderImpl 진입");
 
-        UsernamePasswordAuthenticationToken token = (UsernamePasswordAuthenticationToken) authentication;
-        String username = token.getName();
-        String password = (String) token.getCredentials();
+        String username = authentication.getName();
+        String password = (String) authentication.getCredentials();
 
-        AuthMember loginMember = (AuthMember) service.loadUserByUsername(username);
+        UserDetails loginMember = service.loadUserByUsername(username);
 
         if (!bCryptPasswordEncoder.matches(password, loginMember.getPassword())) {
             throw new MemberException(BaseResponseStatus.INVALID_CHECKED_PASSWORD);

--- a/src/main/java/kuit/project/beering/security/auth/UserDetailsServiceImpl.java
+++ b/src/main/java/kuit/project/beering/security/auth/UserDetailsServiceImpl.java
@@ -7,12 +7,11 @@ import kuit.project.beering.util.exception.domain.MemberException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -28,14 +27,13 @@ public class UserDetailsServiceImpl implements UserDetailsService {
         Member member = memberRepository.findByUsername(username).orElseThrow(() ->
                 new MemberException(BaseResponseStatus.NONE_MEMBER));
 
-        List<GrantedAuthority> authorities = new ArrayList<>();
-        authorities.add(new SimpleGrantedAuthority("MEMBER"));
+        List<GrantedAuthority> authorities = AuthorityUtils.createAuthorityList("ROLE_MEMBER");
 
-        return AuthMember.builder()
-                .id(member.getId())
-                .username(member.getUsername())
-                .password(member.getPassword())
-                .authorities(authorities)
-                .build();
+        return AuthMember.MEMBER(
+                member.getId(),
+                member.getUsername(),
+                authorities
+        );
+
     }
 }

--- a/src/main/java/kuit/project/beering/security/auth/UserDetailsServiceImpl.java
+++ b/src/main/java/kuit/project/beering/security/auth/UserDetailsServiceImpl.java
@@ -32,6 +32,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
         return AuthMember.MEMBER(
                 member.getId(),
                 member.getUsername(),
+                member.getPassword(),
                 authorities
         );
 

--- a/src/main/java/kuit/project/beering/security/jwt/JwtParser.java
+++ b/src/main/java/kuit/project/beering/security/jwt/JwtParser.java
@@ -14,19 +14,6 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class JwtParser {
 
-    /**
-     * @Breif 토큰 서명 검증 없이 클레임 파싱
-     */
-    public Claims parseUnsignedClaims(String token) {
-        try {
-            return Jwts.parserBuilder()
-                    .build()
-                    .parseClaimsJwt(getUnsignedToken(token)).getBody();
-        } catch (ExpiredJwtException e) {
-            throw new CustomJwtException(BaseResponseStatus.EXPIRED_ACCESS_TOKEN);
-        }
-    }
-
     public boolean isJwt(String token) {
         try {
             Jwts.parserBuilder().build().parse(getUnsignedToken(token));
@@ -53,6 +40,19 @@ public class JwtParser {
      */
     private  <T> T parseClaimsField(String token, String field, Class<T> tClass) {
         return parseUnsignedClaims(token).get(field, tClass);
+    }
+
+    /**
+     * @Breif 토큰 서명 검증 없이 클레임 파싱
+     */
+    private Claims parseUnsignedClaims(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .build()
+                    .parseClaimsJwt(getUnsignedToken(token)).getBody();
+        } catch (ExpiredJwtException e) {
+            throw new CustomJwtException(BaseResponseStatus.EXPIRED_ACCESS_TOKEN);
+        }
     }
 
     /**

--- a/src/main/java/kuit/project/beering/security/jwt/jwtTokenProvider/JwtTokenProvider.java
+++ b/src/main/java/kuit/project/beering/security/jwt/jwtTokenProvider/JwtTokenProvider.java
@@ -34,7 +34,7 @@ public class JwtTokenProvider {
 
     private final Key key;
 
-    private final String BEARER = "Bearer ";
+    public final String BEARER = "Bearer ";
     private final JwtParser jwtParser;
 
     public JwtTokenProvider(@Value("${jwt-secret-key}") String secretKey, JwtParser jwtParser) {
@@ -81,7 +81,7 @@ public class JwtTokenProvider {
         String accessToken = Jwts.builder()
                 .setSubject(authentication.getName())
                 .claim("iss", "https://beering.com")
-                .claim("sub", authMember.getId())
+                .claim("sub", String.valueOf(authMember.getId()))
                 .claim("email", authMember.getUsername())
                 .setExpiration(new Date(System.currentTimeMillis() + JWT_EXPIRED_IN))
                 .signWith(key, SignatureAlgorithm.HS256)
@@ -89,7 +89,7 @@ public class JwtTokenProvider {
 
         String refreshToken = Jwts.builder()
                 .claim("iss", "https://beering.com")
-                .claim("sub", authMember.getId())
+                .claim("sub", String.valueOf(authMember.getId()))
                 .claim("email", authMember.getUsername())
                 .setExpiration(new Date(System.currentTimeMillis() + JWT_REFRESH_EXPIRED_IN))
                 .signWith(key, SignatureAlgorithm.HS256)

--- a/src/main/java/kuit/project/beering/service/TokenService.java
+++ b/src/main/java/kuit/project/beering/service/TokenService.java
@@ -3,7 +3,6 @@ package kuit.project.beering.service;
 import kuit.project.beering.dto.request.auth.RefreshTokenRequest;
 import kuit.project.beering.security.jwt.JwtInfo;
 import kuit.project.beering.security.jwt.jwtTokenProvider.JwtTokenProvider;
-import kuit.project.beering.util.exception.CustomJwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -11,13 +10,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 @Slf4j
 public class TokenService {
 
     private final JwtTokenProvider jwtTokenProvider;
 
-    @Transactional(noRollbackFor = CustomJwtException.class)
     public JwtInfo reissueToken(RefreshTokenRequest request) {
 
         return jwtTokenProvider.reissueJwtToken(request.getRefreshToken());


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링 <!--(no functional changes, no api changes)-->
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 : 

### 작업 동기
<!--
  (Optional)
  작업을 왜 하게 되었는지 서술 (ex : 일관성을 위한 리팩토링)
-->

견고한 인증/인가 플로우로 개선하기 위한 리팩토링

## 변경 사항
<!-- 
  변경 사항 및 관련 이슈에 대해 간단하게 작성
  어떻게보다 무엇을 왜 수정했는지 설명
  (ex : 로그인 시, 카카오 소셜 로그인 기능 추가)
-->
1. Autentication 의 principal 객체 role 지정할 때 도메인과 연결된 ROLE(enum)을 사용하도록 변경 -> 일관된 패턴 유지
2. 비로그인 회원 요청 시 GEUST 권한으로 미인증객체 설정


### 주안점
<!--
  (Optional)
  리뷰 시에 유심히 봐주었으면 하는 부분 설명
-->
pr merge 이후에는 비로그인 요청에서 AuthMember가 null 이 아닌 '미인증객체'가 주입됨. isGuest(), isMember() 사용해서 결과에 따라 api 분기 처리하도록 수정.

### 설명
<!--
  (Optional)
  세부 설명이 필요한 경우 기재
-->
jwt 서명 검증 여부에 따라 AuthMember의 권한을  ROLE_GUEST, ROLE_MEMBER로 설정하여 인증객체 설정.
스프링 시큐리티 설정(hasRole("MEMBER"))에 따라 인증회원과 미인증회원의 요청 허용 범위를 구분.

## 체크리스트
- [x] 무엇을 변경했는지 충분히 설명하고 있나요?
- [x] 새로운 기술을 사용했다면, 그 기술을 설명하고 있나요?
- [x] 이해하기 어려운 비즈니스 로직에 관해서 부연 설명을 하고 있나요?
